### PR TITLE
forward bin/build cli arguments to scons to be able to turn off warni…

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -10,4 +10,4 @@ if [ "$(uname -s)" == "Darwin" ]; then
 fi
 
 cd $PROJECT_DIR
-scons mongo -j8 --release $MAC_SDK
+scons mongo -j8 --release $MAC_SDK "$@"

--- a/bin/build.bat
+++ b/bin/build.bat
@@ -1,4 +1,4 @@
-@echo off 
+@echo off
 setlocal enableextensions enabledelayedexpansion
 
 rem -----------------------------------
@@ -17,4 +17,4 @@ rem -----------------------------------
 cd "%PROJECT_DIR%
 
 rem Build mongo shell in release mode
-scons mongo.exe -j8 --release --dynamic-windows
+scons mongo.exe -j8 --release --dynamic-windows %*


### PR DESCRIPTION
Forward the arguments passed to `bin/build` to scons executable to be able to pass additional CFLAGS parameters to the build.

This fixes the issue https://github.com/paralect/robomongo/issues/1021
