### PR TITLE
Fixes clang_64 compiler errors

### DIFF
--- a/src/mongo/db/geo/r2_region_coverer.cpp
+++ b/src/mongo/db/geo/r2_region_coverer.cpp
@@ -70,13 +70,13 @@ R2RegionCoverer::~R2RegionCoverer() {}
 void R2RegionCoverer::setMinLevel(unsigned int minLevel) {
     dassert(minLevel >= 0);
     dassert(minLevel <= GeoHash::kMaxBits);
-    _minLevel = max(0u, min(GeoHash::kMaxBits, minLevel));
+    _minLevel = min(GeoHash::kMaxBits, minLevel);
 }
 
 void R2RegionCoverer::setMaxLevel(unsigned int maxLevel) {
     dassert(maxLevel >= 0);
     dassert(maxLevel <= GeoHash::kMaxBits);
-    _maxLevel = max(0u, min(GeoHash::kMaxBits, maxLevel));
+    _maxLevel = min(GeoHash::kMaxBits, maxLevel);
 }
 
 void R2RegionCoverer::setMaxCells(int maxCells) {

--- a/src/mongo/executor/network_interface_asio.cpp
+++ b/src/mongo/executor/network_interface_asio.cpp
@@ -394,7 +394,7 @@ Status NetworkInterfaceASIO::startCommand(const TaskExecutor::CallbackHandle& cb
                 }
 
                 op->_timeoutAlarm->asyncWait(
-                    [this, op, access, generation, requestId, adjustedTimeout](std::error_code ec) {
+                    [op, access, generation, requestId, adjustedTimeout](std::error_code ec) {
                         // We must pass a check for safe access before using op inside the
                         // callback or we may attempt access on an invalid pointer.
                         stdx::lock_guard<stdx::mutex> lk(access->mutex);

--- a/src/mongo/executor/network_interface_asio_command.cpp
+++ b/src/mongo/executor/network_interface_asio_command.cpp
@@ -386,7 +386,7 @@ void NetworkInterfaceASIO::_asyncRunCommand(AsyncOp* op, NetworkOpHandler handle
     auto cmd = op->command();
 
     // Step 4
-    auto recvMessageCallback = [this, cmd, handler, op](std::error_code ec, size_t bytes) {
+    auto recvMessageCallback = [handler](std::error_code ec, size_t bytes) {
         // We don't call _validateAndRun here as we assume the caller will.
         handler(ec, bytes);
     };
@@ -396,7 +396,7 @@ void NetworkInterfaceASIO::_asyncRunCommand(AsyncOp* op, NetworkOpHandler handle
                                                                             size_t bytes) {
         // The operation could have been canceled after starting the command, but before
         // receiving the header
-        _validateAndRun(op, ec, [this, op, recvMessageCallback, ec, bytes, cmd, handler] {
+        _validateAndRun(op, ec, [recvMessageCallback, bytes, cmd, handler] {
             // validate response id
             uint32_t expectedId = cmd->toSend().header().getId();
             uint32_t actualId = cmd->header().constView().getResponseToMsgId();
@@ -417,7 +417,7 @@ void NetworkInterfaceASIO::_asyncRunCommand(AsyncOp* op, NetworkOpHandler handle
     // Step 2
     auto sendMessageCallback = [this, cmd, handler, recvHeaderCallback, op](std::error_code ec,
                                                                             size_t bytes) {
-        _validateAndRun(op, ec, [this, cmd, op, recvHeaderCallback] {
+        _validateAndRun(op, ec, [cmd, recvHeaderCallback] {
             asyncRecvMessageHeader(
                 cmd->conn().stream(), &cmd->header(), std::move(recvHeaderCallback));
         });

--- a/src/mongo/executor/thread_pool_task_executor.cpp
+++ b/src/mongo/executor/thread_pool_task_executor.cpp
@@ -287,7 +287,7 @@ StatusWith<TaskExecutor::CallbackHandle> ThreadPoolTaskExecutor::scheduleWorkAt(
         return cbHandle;
     }
     lk.unlock();
-    _net->setAlarm(when, [this, when, cbHandle] {
+    _net->setAlarm(when, [this, cbHandle] {
         auto cbState = checked_cast<CallbackState*>(getCallbackFromHandle(cbHandle.getValue()));
         if (cbState->canceled.load()) {
             return;

--- a/src/mongo/util/assert_util.cpp
+++ b/src/mongo/util/assert_util.cpp
@@ -308,7 +308,7 @@ string demangleName(const type_info& typeinfo) {
 #endif
 }
 
-Status exceptionToStatus() noexcept {
+Status exceptionToStatus() {
     try {
         throw;
     } catch (const DBException& ex) {

--- a/src/mongo/util/assert_util.h
+++ b/src/mongo/util/assert_util.h
@@ -464,7 +464,7 @@ std::string demangleName(const std::type_info& typeinfo);
  *       }
  *   }
  */
-Status exceptionToStatus() noexcept;
+Status exceptionToStatus();
 
 }  // namespace mongo
 

--- a/src/mongo/util/net/hostname_canonicalization.cpp
+++ b/src/mongo/util/net/hostname_canonicalization.cpp
@@ -92,7 +92,7 @@ std::vector<std::string> getHostFQDNs(std::string hostName, HostnameCanonicaliza
                << getAddrInfoStrError(err);
         return results;
     }
-    const auto guard = MakeGuard([&shim_freeaddrinfo, &info] { shim_freeaddrinfo(info); });
+    const auto guard = MakeGuard([&info] { shim_freeaddrinfo(info); });
 
     if (mode == HostnameCanonicalizationMode::kForward) {
         results.emplace_back(shim_fromNativeString(info->ai_canonname));

--- a/src/third_party/s2/util/math/mathutil.cc
+++ b/src/third_party/s2/util/math/mathutil.cc
@@ -27,7 +27,7 @@ using std::vector;
     return static_cast<IntOut>(x < 0 ? (x - 0.5) : (x + 0.5));
   }
 
-template int MathUtil::Round<int,double>(double x);
+//template int MathUtil::Round<int,double>(double x);
 
 MathUtil::QuadraticRootType MathUtil::RealRootsForQuadratic(long double a,
                                                         long double b,


### PR DESCRIPTION
This PR removes redundant and erroneous code/modifiers that were causing errors and build termination when using Clang x64 compiler. See commits for details.